### PR TITLE
bindings/macro: add visibility modifier support

### DIFF
--- a/crates/bindings/macro/src/attr.rs
+++ b/crates/bindings/macro/src/attr.rs
@@ -1,8 +1,10 @@
 use syn::parse::{Parse, ParseStream};
+use syn::Visibility;
 use syn::{Ident, Path, Result};
 
 pub(crate) struct TransformAttributes {
     pub module: Option<Path>,
+    pub visibility: Option<Visibility>,
     pub context: Option<Path>,
 }
 
@@ -10,6 +12,7 @@ impl Parse for TransformAttributes {
     fn parse(input: ParseStream) -> Result<Self> {
         let mut module = None;
         let mut context = None;
+        let mut visibility = None;
 
         while !input.is_empty() {
             let i: Ident = input.parse()?;
@@ -24,6 +27,11 @@ impl Parse for TransformAttributes {
                     parenthesized!(content in input);
                     context = Some(content.parse::<Path>()?);
                 }
+                "visibility" => {
+                    let content;
+                    parenthesized!(content in input);
+                    visibility = Some(content.parse::<Visibility>()?);
+                }
                 _ => {
                     return Err(input.error(format!("unexpected attr name {}", i.to_string())));
                 }
@@ -33,6 +41,10 @@ impl Parse for TransformAttributes {
             }
             input.parse::<Token![,]>()?;
         }
-        Ok(TransformAttributes { module, context })
+        Ok(TransformAttributes {
+            module,
+            context,
+            visibility,
+        })
     }
 }

--- a/crates/bindings/macro/src/impl.rs
+++ b/crates/bindings/macro/src/impl.rs
@@ -93,8 +93,8 @@ fn generate_method_wrapper(
 }
 
 pub(crate) fn wrap_impl(tr: ItemImpl, attr: TransformAttributes) -> TokenStream {
-    // TODO review visibility for module, add visibility attr??
-    let vis = &Visibility::Inherited;
+    let vis = attr.visibility.as_ref().unwrap_or(&Visibility::Inherited);
+
     let ident = if let Type::Path(tp) = tr.self_ty.as_ref() {
         tp
     } else {
@@ -135,11 +135,13 @@ pub(crate) fn wrap_impl(tr: ItemImpl, attr: TransformAttributes) -> TokenStream 
     }
 
     let mod_item_vis = match vis {
+        Visibility::Public(p) => quote! { #p },
+        Visibility::Crate(c) => quote! { #c },
+        Visibility::Restricted(r) => quote! { #r },
         Visibility::Inherited => quote! { pub(super) },
-        vis => quote! { #vis },
     };
     let mod_content = quote! {
-        #vis mod #mod_name {
+        #mod_item_vis mod #mod_name {
             use super::*;
             use #wasmtime_bindings :: {
                 VMContext, InstanceHandle, InstanceHandleExport,


### PR DESCRIPTION
First, this fixes a typo where the hardcoded `Inherited` visiblity
wasn't properly set due to a variable name mixup.

Second, this adds support for a visibility attribute to the `wrap_impl`
macro.

I tested the _pub_ modifier, only manually, all others are completely
untested.